### PR TITLE
`speech-instructions.md` split and moved into corresponding README files for #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Link to Doxygen generated documentation: http://robots.uc3m.es/dox-speech
 
 ## Installation
 
-Installation instructions for installing from source can be found [here]( doc/speech-install.md ).
+Installation instructions for installing from source can be found [here](doc/speech-install.md).
 
 ## Usage
 
 Information of how to launch or configure it:
-1. [Speech recognition](https://github.com/roboticslab-uc3m/speech/tree/develop/programs/speechRecognition/README.md)
-2. [Espeak](https://github.com/roboticslab-uc3m/speech/tree/develop/libraries/YarpPlugins/Espeak/README.md)
+1. [Speech recognition](programs/speechRecognition/README.md)
+2. [Espeak](libraries/YarpPlugins/Espeak/README.md)
 
 ##### More examples:
 To see how other programs call to `speechRecognition ` and  `Espeak` and configure it by yarp, you can see this part of the [follow-me](https://github.com/roboticslab-uc3m/follow-me/blob/develop/programs/followMeDialogueManager/FollowMeDialogueManager.cpp#L10-L100)  code.
@@ -21,7 +21,7 @@ To see how other programs call to `speechRecognition ` and  `Espeak` and configu
 
 #### Posting Issues
 
-1. Read [CONTRIBUTING.md](https://github.com/roboticslab-uc3m/speech/blob/master/CONTRIBUTING.md)
+1. Read [CONTRIBUTING.md](CONTRIBUTING.md)
 2. [Post an issue / Feature request / Specific documentation request](https://github.com/roboticslab-uc3m/speech/issues)
 
 #### Fork & Pull Request

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Information of how to launch or configure it:
 1. [Speech recognition](https://github.com/roboticslab-uc3m/speech/tree/develop/programs/speechRecognition/README.md)
 2. [Espeak](https://github.com/roboticslab-uc3m/speech/tree/develop/libraries/YarpPlugins/Espeak/README.md)
 
-### More examples:
+##### More examples:
 To see how other programs call to `speechRecognition ` and  `Espeak` and configure it by yarp, you can see this part of the [follow-me](https://github.com/roboticslab-uc3m/follow-me/blob/develop/programs/followMeDialogueManager/FollowMeDialogueManager.cpp#L10-L100)  code.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ Installation instructions for installing from source can be found [here]( doc/sp
 
 ## Usage
 
-Information of how to launch or configure it can be found [here](/doc/speech-instructions.md)
+Information of how to launch or configure it:
+1. [Speech recognition](https://github.com/roboticslab-uc3m/speech/tree/develop/programs/speechRecognition/README.md)
+2. [Espeak](https://github.com/roboticslab-uc3m/speech/tree/develop/libraries/YarpPlugins/Espeak/README.md)
+
+### More examples:
+To see how other programs call to `speechRecognition ` and  `Espeak` and configure it by yarp, you can see this part of the [follow-me](https://github.com/roboticslab-uc3m/follow-me/blob/develop/programs/followMeDialogueManager/FollowMeDialogueManager.cpp#L10-L100)  code.
 
 ## Contributing
 

--- a/libraries/YarpPlugins/Espeak/README.md
+++ b/libraries/YarpPlugins/Espeak/README.md
@@ -1,11 +1,11 @@
-# Speech software:
+# Speech software
 
-### How to launch:
-1. First, follow the steeps descripted on [installation instruction](https://github.com/roboticslab-uc3m/speech/blob/develop/doc/speech-install.md)
-2. Be sure you have a sound speaker connected to your computer and correctly configurated (you can do it using `AlsaMixer` or directly in sound settings)
+### How to launch
+1. First, follow the steps described on [installation instruction](https://github.com/roboticslab-uc3m/speech/blob/develop/doc/speech-install.md)
+2. Be sure you have a sound speaker connected to your computer and correctly configured (you can do it using `AlsaMixer` or directly in sound settings)
 3. Run on the terminal `yarpdev --device Espeak --name /tts`. The bash will show you some information:
 
-	```sh
+	```bash
 	--name: /tts [/espeak]
 	--voice: mb-en1 [mb-en1]
 	[success] Espeak.cpp:44 setLanguage(): mb-en1
@@ -19,11 +19,11 @@
 	[INFO]device active in background...
 	```
 
-### How to configure it:
+### How to configure it
 
-Once the speech software has started, connect it through the opened yarp port using `yarp rpc /tts/rpc:s` in other terminal. You can see all the available commands writting `help` command:
+Once the speech software has started, connect it through the opened yarp port using `yarp rpc /tts/rpc:s` in another terminal. You can see all the available commands writting the `help` command:
 
-```sh
+```bash
 Responses:
   *** Available commands:
   setLanguage
@@ -38,7 +38,7 @@ Responses:
   stop
   help
 ```
-### Examples of use:
+### Examples of use
 
 ```sh
 >> say "Hello Teo"

--- a/libraries/YarpPlugins/Espeak/README.md
+++ b/libraries/YarpPlugins/Espeak/README.md
@@ -1,0 +1,53 @@
+# Speech software:
+
+### How to launch:
+1. First, follow the steeps descripted on [installation instruction](https://github.com/roboticslab-uc3m/speech/blob/develop/doc/speech-install.md)
+2. Be sure you have a sound speaker connected to your computer and correctly configurated (you can do it using `AlsaMixer` or directly in sound settings)
+3. Run on the terminal `yarpdev --device Espeak --name /tts`. The bash will show you some information:
+
+	```sh
+	--name: /tts [/espeak]
+	--voice: mb-en1 [mb-en1]
+	[success] Espeak.cpp:44 setLanguage(): mb-en1
+	yarp: Port /tts/rpc:s active at tcp://2.2.2.100:10061/
+	[INFO]created device <Espeak>. See C++ class roboticslab::Espeak for documentation.
+	yarp: Port /tts/quit active at tcp://2.2.2.100:10062/
+	[INFO]device active in background...
+	[INFO]device active in background...
+	[INFO]device active in background...
+	[INFO]device active in background...
+	[INFO]device active in background...
+	```
+
+### How to configure it:
+
+Once the speech software has started, connect it through the opened yarp port using `yarp rpc /tts/rpc:s` in other terminal. You can see all the available commands writting `help` command:
+
+```sh
+Responses:
+  *** Available commands:
+  setLanguage
+  setSpeed
+  setPitch
+  getSpeed
+  getPitch
+  getSupportedLang
+  say
+  play
+  pause
+  stop
+  help
+```
+### Examples of use:
+
+```sh
+>> say "Hello Teo"
+>> setPitch 200
+>> say "Hello Teo"
+>> setLanguage mb-es1
+>> say "Hola Teo"
+>> setSpeed 10
+>> say "Hola Teo"
+>> setLanguage mb-en1
+>> say "It's very cool"
+```

--- a/programs/speechRecognition/README.md
+++ b/programs/speechRecognition/README.md
@@ -1,18 +1,18 @@
 # Speech recognition software
 
-### How to launch:
-1. First, follow the steps descripted on [installation instruction](https://github.com/roboticslab-uc3m/speech/blob/develop/doc/speech-install.md)
-2. Be sure you have a microphone connected to your computer
-3. Configure the input device selecting the microphone. You can use the  default `sound settings` of Ubuntu and selecting  the input device. This requires using the Ubuntu interface. If you want to configure it remotely (by ssh), you can use `AlsaMixer` software.
-In that case, run `alsamixer` on the bash,  press F6, select your Sound Card (e.g HDA Intel PCH), press F4 and select your Input Source (Front Mic). You can turn up/down the input level too.
-4. Run `speechRecognition.py`. By default it takes `follow-me-english.dic` dictionary.  If you want to: know, change or add new dictionary words, you can find them in: `speech/share/speechRecognition/conf/dictionary/` directory.
-5. Try to say some orders of  `follow-me`  demo using the microphone and check if 'speechRecognition' detects de words.
-6. The final result in lower case comes out through a yarp port. You can connect it with the output port writting `yarp read ... /speechRecognition:o`
+### How to launch
+1. First, follow the steps described on [installation instructions](https://github.com/roboticslab-uc3m/speech/blob/develop/doc/speech-install.md)
+2. Be sure you have a microphone connected to your computer.
+3. Configure the input device selecting the microphone. You can use the  default `sound settings` of Ubuntu and select the input device. This requires using the Ubuntu interface. If you want to configure it remotely (by ssh), you can use the `alsamixer` software.
+In that case, run `alsamixer` on the bash,  press `F6`, select your Sound Card (e.g HDA Intel PCH), press `F4` and select your `Input Source (Front Mic)`. You can turn the input level up/down too.
+4. Run `speechRecognition.py`. By default it uses the `follow-me-english.dic` dictionary.  If you want to: know, change or add new dictionary words, you can find them in: `speech/share/speechRecognition/conf/dictionary/` directory.
+5. Try to say some orders of  `follow-me`  demo using the microphone and check if `speechRecognition` detects de words.
+6. The final result in lower case comes out through a yarp port. You can read from the output port writing `yarp read ... /speechRecognition:o`.
 
-### How to configure it:
+### How to configure it
 
-Once `speechRecognition.py` has started, connect it to yarp configuration dictionary port and change the language to use. 
-For example, if you want to change to waiter spanish orders, put:
+Once `speechRecognition.py` has started, connect it to the yarp configuration dictionary port and change the language to use. 
+For example, if you want to change to waiter Spanish orders, put:
 
 ```bash
 yarp rpc /speechRecognition/rpc:s

--- a/programs/speechRecognition/README.md
+++ b/programs/speechRecognition/README.md
@@ -1,0 +1,20 @@
+# Speech recognition software
+
+### How to launch:
+1. First, follow the steps descripted on [installation instruction](https://github.com/roboticslab-uc3m/speech/blob/develop/doc/speech-install.md)
+2. Be sure you have a microphone connected to your computer
+3. Configure the input device selecting the microphone. You can use the  default `sound settings` of Ubuntu and selecting  the input device. This requires using the Ubuntu interface. If you want to configure it remotely (by ssh), you can use `AlsaMixer` software.
+In that case, run `alsamixer` on the bash,  press F6, select your Sound Card (e.g HDA Intel PCH), press F4 and select your Input Source (Front Mic). You can turn up/down the input level too.
+4. Run `speechRecognition.py`. By default it takes `follow-me-english.dic` dictionary.  If you want to: know, change or add new dictionary words, you can find them in: `speech/share/speechRecognition/conf/dictionary/` directory.
+5. Try to say some orders of  `follow-me`  demo using the microphone and check if 'speechRecognition' detects de words.
+6. The final result in lower case comes out through a yarp port. You can connect it with the output port writting `yarp read ... /speechRecognition:o`
+
+### How to configure it:
+
+Once `speechRecognition.py` has started, connect it to yarp configuration dictionary port and change the language to use. 
+For example, if you want to change to waiter spanish orders, put:
+
+```bash
+yarp rpc /speechRecognition/rpc:s
+setDictionary waiter spanish
+```


### PR DESCRIPTION
`speech-instructions.md` splited and moved into corresponding README files, for #22